### PR TITLE
fix(config): enable pinch-zoom by default

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Vcs-Git: https://github.com/JoseExposito/touchegg.git
 Package: touchegg
 Architecture: amd64
 Depends: ${misc:Depends}, ${shlibs:Depends}
+Recommends: xdotool
 Description: Multi-touch gesture recognizer
  Touchégg is an app that runs in the background and transform the gestures you
  make in your touchpad into visible actions in your desktop.

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -140,4 +140,20 @@
       </action>
     </gesture>
   </application>
+  <application name="gimp">
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="SEND_KEYS">
+        <repeat>true</repeat>
+        <keys>KP_Subtract</keys>
+        <decreaseKeys>KP_Add</decreaseKeys>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="SEND_KEYS">
+        <repeat>true</repeat>
+        <keys>KP_Add</keys>
+        <decreaseKeys>KP_Subtract</decreaseKeys>
+      </action>
+    </gesture>
+  </application>
 </touchégg>

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -119,11 +119,66 @@
         <on>begin</on>
       </action>
     </gesture>
+
+    <!--
+      Gestures for 1:1 workspaces tracking
+    -->
+    <gesture type="SWIPE" fingers="4" direction="UP"><action type="GNOME_SHELL"></action></gesture>
+    <gesture type="SWIPE" fingers="4" direction="DOWN"><action type="GNOME_SHELL"></action></gesture>
   </application>
 
   <!-- 
     Application-specific Configuration 
   -->
+  <application name="gimp-2.10">
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key minus</command>
+        <decreaseCommand>xdotool key plus</decreaseCommand>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key plus</command>
+        <decreaseCommand>xdotool key minus</decreaseCommand>
+      </action>
+    </gesture>
+  </application>
+  <application name="glimpse-0.2">
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key minus</command>
+        <decreaseCommand>xdotool key plus</decreaseCommand>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key plus</command>
+        <decreaseCommand>xdotool key minus</decreaseCommand>
+      </action>
+    </gesture>
+  </application>
+  <application name="gnome-terminal">
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key Ctrl+Shift+plus</command>
+        <decreaseCommand>xdotool key Ctrl+minus</decreaseCommand>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="RUN_COMMAND">
+        <command>xdotool key Ctrl+minus</command>
+        <repeat>true</repeat>
+        <animation>CHANGE_DESKTOP_UP</animation>
+        <decreaseCommand>xdotool key Ctrl+Shift+plus</decreaseCommand>
+      </action>
+    </gesture>
+  </application>
   <application name="inkscape">
     <gesture type="PINCH" fingers="2" direction="IN">
       <action type="SEND_KEYS">
@@ -140,19 +195,19 @@
       </action>
     </gesture>
   </application>
-  <application name="gimp">
+  <application name="tilix">
     <gesture type="PINCH" fingers="2" direction="IN">
-      <action type="SEND_KEYS">
+      <action type="RUN_COMMAND">
         <repeat>true</repeat>
-        <keys>KP_Subtract</keys>
-        <decreaseKeys>KP_Add</decreaseKeys>
+        <command>xdotool key Ctrl+minus</command>
+        <decreaseCommand>xdotool key Ctrl+Shift+plus</decreaseCommand>
       </action>
     </gesture>
     <gesture type="PINCH" fingers="2" direction="OUT">
-      <action type="SEND_KEYS">
+      <action type="RUN_COMMAND">
         <repeat>true</repeat>
-        <keys>KP_Add</keys>
-        <decreaseKeys>KP_Subtract</decreaseKeys>
+        <command>xdotool key Ctrl+Shift+plus</command>
+        <decreaseCommand>xdotool key Ctrl+minus</decreaseCommand>
       </action>
     </gesture>
   </application>

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -130,7 +130,7 @@
   <!-- 
     Application-specific Configuration 
   -->
-  <application name="gimp-2.10">
+  <application name="gimp-2.10,glimpse-2.0">
     <gesture type="PINCH" fingers="2" direction="IN">
       <action type="RUN_COMMAND">
         <repeat>true</repeat>
@@ -146,23 +146,7 @@
       </action>
     </gesture>
   </application>
-  <application name="glimpse-0.2">
-    <gesture type="PINCH" fingers="2" direction="IN">
-      <action type="RUN_COMMAND">
-        <repeat>true</repeat>
-        <command>xdotool key minus</command>
-        <decreaseCommand>xdotool key plus</decreaseCommand>
-      </action>
-    </gesture>
-    <gesture type="PINCH" fingers="2" direction="OUT">
-      <action type="RUN_COMMAND">
-        <repeat>true</repeat>
-        <command>xdotool key plus</command>
-        <decreaseCommand>xdotool key minus</decreaseCommand>
-      </action>
-    </gesture>
-  </application>
-  <application name="gnome-terminal">
+  <application name="gnome-terminal,tilix">
     <gesture type="PINCH" fingers="2" direction="OUT">
       <action type="RUN_COMMAND">
         <repeat>true</repeat>
@@ -192,22 +176,6 @@
         <repeat>true</repeat>
         <keys>KP_Add</keys>
         <decreaseKeys>KP_Subtract</decreaseKeys>
-      </action>
-    </gesture>
-  </application>
-  <application name="tilix">
-    <gesture type="PINCH" fingers="2" direction="IN">
-      <action type="RUN_COMMAND">
-        <repeat>true</repeat>
-        <command>xdotool key Ctrl+minus</command>
-        <decreaseCommand>xdotool key Ctrl+Shift+plus</decreaseCommand>
-      </action>
-    </gesture>
-    <gesture type="PINCH" fingers="2" direction="OUT">
-      <action type="RUN_COMMAND">
-        <repeat>true</repeat>
-        <command>xdotool key Ctrl+Shift+plus</command>
-        <decreaseCommand>xdotool key Ctrl+minus</decreaseCommand>
       </action>
     </gesture>
   </application>

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -130,7 +130,7 @@
   <!-- 
     Application-specific Configuration 
   -->
-  <application name="gimp-2.10,glimpse-2.0">
+  <application name="gimp-2.10">
     <gesture type="PINCH" fingers="2" direction="IN">
       <action type="RUN_COMMAND">
         <repeat>true</repeat>
@@ -146,7 +146,23 @@
       </action>
     </gesture>
   </application>
-  <application name="gnome-terminal,tilix">
+  <application name="glimpse-0.2">
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key minus</command>
+        <decreaseCommand>xdotool key plus</decreaseCommand>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key plus</command>
+        <decreaseCommand>xdotool key minus</decreaseCommand>
+      </action>
+    </gesture>
+  </application>
+  <application name="gnome-terminal">
     <gesture type="PINCH" fingers="2" direction="OUT">
       <action type="RUN_COMMAND">
         <repeat>true</repeat>
@@ -176,6 +192,22 @@
         <repeat>true</repeat>
         <keys>KP_Add</keys>
         <decreaseKeys>KP_Subtract</decreaseKeys>
+      </action>
+    </gesture>
+  </application>
+  <application name="tilix">
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key Ctrl+minus</command>
+        <decreaseCommand>xdotool key Ctrl+Shift+plus</decreaseCommand>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="RUN_COMMAND">
+        <repeat>true</repeat>
+        <command>xdotool key Ctrl+Shift+plus</command>
+        <decreaseCommand>xdotool key Ctrl+minus</decreaseCommand>
       </action>
     </gesture>
   </application>

--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -40,6 +40,22 @@
     Configuration for every application.
   -->
   <application name="All">
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="SEND_KEYS">
+        <repeat>true</repeat>
+        <modifiers>Control_L</modifiers>
+        <keys>KP_Subtract</keys>
+        <decreaseKeys>KP_Add</decreaseKeys>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="SEND_KEYS">
+        <repeat>true</repeat>
+        <modifiers>Control_L</modifiers>
+        <keys>KP_Add</keys>
+        <decreaseKeys>KP_Subtract</decreaseKeys>
+      </action>
+    </gesture>
     <gesture type="SWIPE" fingers="3" direction="UP">
       <action type="RUN_COMMAND">
         <repeat>false</repeat>
@@ -101,6 +117,26 @@
         <repeat>false</repeat>
         <command>dbus-send --session --dest=com.System76.Cosmic --type=method_call /com/System76/Cosmic com.System76.Cosmic.GestureRight</command>
         <on>begin</on>
+      </action>
+    </gesture>
+  </application>
+
+  <!-- 
+    Application-specific Configuration 
+  -->
+  <application name="inkscape">
+    <gesture type="PINCH" fingers="2" direction="IN">
+      <action type="SEND_KEYS">
+        <repeat>true</repeat>
+        <keys>KP_Subtract</keys>
+        <decreaseKeys>KP_Add</decreaseKeys>
+      </action>
+    </gesture>
+    <gesture type="PINCH" fingers="2" direction="OUT">
+      <action type="SEND_KEYS">
+        <repeat>true</repeat>
+        <keys>KP_Add</keys>
+        <decreaseKeys>KP_Subtract</decreaseKeys>
       </action>
     </gesture>
   </application>


### PR DESCRIPTION
This just maps to the default Ctrl+ and Ctrl- keyboard shortcuts for zoom which are default in most applications which support it. There are some applications for which we may want to add custom configuration; a default configuration for inkscape is included.

I believe the modifications to the conf file will work correctly to enable this. 