### PR TITLE
Enable arm64 build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Vcs-Browser: https://github.com/JoseExposito/touchegg
 Vcs-Git: https://github.com/JoseExposito/touchegg.git
 
 Package: touchegg
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Multi-touch gesture recognizer
  Touchégg is an app that runs in the background and transform the gestures you


### PR DESCRIPTION
Fixes held `pop-session` upgrade on arm64 installs.