### PR TITLE
Fix swipe for workspaces

### DIFF
--- a/installation/touchegg.conf
+++ b/installation/touchegg.conf
@@ -105,7 +105,7 @@
     </gesture>
 
     <gesture type="SWIPE" fingers="4" direction="LEFT">
-      <action type="RUN_COMAND">
+      <action type="RUN_COMMAND">
         <repeat>false</repeat>
         <command>dbus-send --session --dest=com.System76.Cosmic --type=method_call /com/System76/Cosmic com.System76.Cosmic.GestureLeft</command>
         <on>begin</on>


### PR DESCRIPTION
Typo caused config to be parsed improperly, thus touchegg skipped the config.

Closes #11 